### PR TITLE
Fix OSX Dynamic Linker

### DIFF
--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -112,7 +112,6 @@ elseif( COMPILER_SUPPORTS_CXX0X)
 else()
     # MSVC, On by default (if available)
 endif()
-ucm_add_flags(-w)
 
 # Append the `src`
 add_subdirectory(src)

--- a/contrib/cmake/CMakeLists.txt
+++ b/contrib/cmake/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ECC Build System
-# 
+#
 # This CMakeLists.txt is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
 # with or without modifications, as long as this notice is preserved.
@@ -35,7 +35,7 @@ include(ucm)
 
 #
 # Generate Project Information
-# 
+#
 # Get git revision
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 string(SUBSTRING "${GIT_SHA1}" 0 12 GIT_REV)
@@ -59,17 +59,17 @@ set(META_CMAKE_INIT_SHA      "${GIT_SHA1}")
 string(MAKE_C_IDENTIFIER ${META_PROJECT_NAME} META_PROJECT_ID)
 string(TOUPPER ${META_PROJECT_ID} META_PROJECT_ID)
 
-# 
+#
 # Project configuration options
-# 
+#
 
 # Project options
 option(OPTION_BUILD_TESTS    "Build tests."                       ON)
 option(OPTION_BUILD_DOCS     "Build documentation."              OFF)
 
-# 
+#
 # Declare project
-# 
+#
 
 # Generate folders for IDE targets (e.g., VisualStudio solutions)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -86,9 +86,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 # Create version file
 file(WRITE "${PROJECT_BINARY_DIR}/VERSION" "${META_NAME_VERSION}")
 
-# 
+#
 # Compiler settings and options
-# 
+#
 include(CompileOptions)
 ucm_add_flags(CXX ${DEFAULT_COMPILE_OPTIONS})
 ucm_add_linker_flags(${DEFAULT_LINKER_OPTIONS})
@@ -112,6 +112,7 @@ elseif( COMPILER_SUPPORTS_CXX0X)
 else()
     # MSVC, On by default (if available)
 endif()
+ucm_add_flags(-w)
 
 # Append the `src`
 add_subdirectory(src)

--- a/contrib/cmake/modules/CompileOptions.cmake
+++ b/contrib/cmake/modules/CompileOptions.cmake
@@ -1,7 +1,7 @@
 
-# 
+#
 # Platform and architecture setup
-# 
+#
 
 # Get upper case system name
 string(TOUPPER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME_UPPER)
@@ -13,9 +13,9 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif()
 
 
-# 
+#
 # Project options
-# 
+#
 
 set(DEFAULT_PROJECT_OPTIONS
     DEBUG_POSTFIX             "d"
@@ -26,23 +26,23 @@ set(DEFAULT_PROJECT_OPTIONS
 )
 
 
-# 
+#
 # Include directories
-# 
+#
 
 set(DEFAULT_INCLUDE_DIRECTORIES)
 
 
-# 
+#
 # Libraries
-# 
+#
 
 set(DEFAULT_LIBRARIES)
 
 
-# 
+#
 # Compile definitions
-# 
+#
 
 set(DEFAULT_COMPILE_DEFINITIONS
     SYSTEM_${SYSTEM_NAME_UPPER}
@@ -57,9 +57,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
 endif ()
 
 
-# 
+#
 # Compile options
-# 
+#
 
 set(DEFAULT_COMPILE_OPTIONS)
 
@@ -74,18 +74,18 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
         /wd4592       # -> disable warning: 'identifier': symbol will be dynamically initialized (implementation limitation)
         # /wd4201     # -> disable warning: nonstandard extension used: nameless struct/union (caused by GLM)
         # /wd4127     # -> disable warning: conditional expression is constant (caused by Qt)
-        
+
         #$<$<CONFIG:Debug>:
         #/RTCc         # -> value is assigned to a smaller data type and results in a data loss
         #>
 
-        $<$<CONFIG:Release>: 
+        $<$<CONFIG:Release>:
         /Gw           # -> whole program global optimization
-        /GS-          # -> buffer security check: no 
+        /GS-          # -> buffer security check: no
         /GL           # -> whole program optimization: enable link-time code generation (disables Zi)
         /GF           # -> enable string pooling
         >
-        
+
         # No manual c++11 enable for MSVC as all supported MSVC versions for cmake-init have C++11 implicitly enabled (MSVC >=2013)
     )
 endif ()
@@ -105,13 +105,14 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
         -Wswitch-default
         -Wuninitialized
         -Wmissing-field-initializers
+        -w # disable all warnings
     )
 endif ()
 
 
-# 
+#
 # Linker options
-# 
+#
 
 set(DEFAULT_LINKER_OPTIONS)
 

--- a/contrib/cmake/modules/FindBerkeleyDB.cmake
+++ b/contrib/cmake/modules/FindBerkeleyDB.cmake
@@ -12,11 +12,14 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 find_path(BERKELEY_DB_INCLUDE_DIR db_cxx.h
+  /usr/local/opt/berkeley-db@4/include
   /usr/include/db4
   /usr/local/include/db4
 )
 
-find_library(BERKELEY_DB_LIBRARIES NAMES db_cxx )
+find_library(BERKELEY_DB_LIBRARIES NAMES db_cxx HINTS
+  /usr/local/opt/berkeley-db@4/lib
+)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Berkeley "Could not find Berkeley DB >= 4.1" BERKELEY_DB_INCLUDE_DIR BERKELEY_DB_LIBRARIES)

--- a/contrib/cmake/modules/FindGMP.cmake
+++ b/contrib/cmake/modules/FindGMP.cmake
@@ -1,0 +1,24 @@
+# Try to find the GMP librairies
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+# Copyright (c) 2006, Laurent Montel, <montel@kde.org>
+#
+# Redistribution and use is allowed according to the terms of the BSD
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+    # Already in cache, be silent
+    set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h HINTS "./local/include")
+find_library(GMP_LIBRARIES NAMES gmp libgmp HINTS "./local/lib")
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx HINTS "./local/lib")
+MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)

--- a/contrib/cmake/modules/FindLibEvent.cmake
+++ b/contrib/cmake/modules/FindLibEvent.cmake
@@ -8,10 +8,12 @@ set(LibEvent_EXTRA_PREFIXES /usr/local /opt/local "$ENV{HOME}")
 foreach(prefix ${LibEvent_EXTRA_PREFIXES})
   list(APPEND LibEvent_INCLUDE_PATHS "${prefix}/include")
   list(APPEND LibEvent_LIB_PATHS "${prefix}/lib")
+  list(APPEND LibEvent_LIB_PATHS "/usr/local/Cellar/libevent/2.1.8/lib")
 endforeach()
 
 find_path(LIBEVENT_INCLUDE_DIR event.h PATHS ${LibEvent_INCLUDE_PATHS})
-find_library(LIBEVENT_LIB NAMES event PATHS ${LibEvent_LIB_PATHS})
+find_library(LIBEVENT_LIB NAMES event PATHS "/usr/local/Cellar/libevent/2.1.8/lib")
+find_library(LIBEVENT_PTHREADS_LIB NAMES event_pthreads PATHS "/usr/local/Cellar/libevent/2.1.8/lib")
 
 if (LIBEVENT_LIB AND LIBEVENT_INCLUDE_DIR)
   set(LibEvent_FOUND TRUE)
@@ -34,4 +36,5 @@ endif ()
 mark_as_advanced(
     LIBEVENT_LIB
     LIBEVENT_INCLUDE_DIR
+    LIBEVENT_PTHREADS_LIB
   )

--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -234,7 +234,6 @@ include_directories(${OPENSSL_INCLUDE_DIR})
 #
 find_package(LibEvent REQUIRED)
 include_directories(${LIBEVENT_INCLUDE_DIR})
-# ucm_add_linker_flags(SHARED ${LIBEVENT_LIB})
 
 #
 # BerkeleyDB
@@ -242,7 +241,6 @@ include_directories(${LIBEVENT_INCLUDE_DIR})
 set(DB_VERSION 47)
 find_package(BerkeleyDB REQUIRED)
 include_directories(${BERKELEY_DB_INCLUDE_DIR})
-# ucm_add_linker_flags(SHARED ${BERKELEY_DB_LIBRARIES})
 
 #
 # LevelDB
@@ -305,34 +303,34 @@ set(ECC_LIBS
 
 #--------------------------------------------------------------------------------
 #  CMake's way of creating an executable
-add_executable(eccoind MACOSX_BUNDLE WIN32
+add_executable(Eccoind MACOSX_BUNDLE WIN32
   ${DIR_HEADERS}
   ${DIR_SOURCES}
 )
-add_dependencies(eccoind secp256k1)
+add_dependencies(Eccoind secp256k1)
 
 # Link the libraries into the binary
-target_link_libraries(eccoind ${ECC_LIBS})
+target_link_libraries(Eccoind ${ECC_LIBS})
 
 #--------------------------------------------------------------------------------
 # Now the installation stuff below
 #--------------------------------------------------------------------------------
 SET(plugin_dest_dir bin)
 SET(qtconf_dest_dir bin)
-SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/eccoind")
+SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/Eccoind")
 IF(APPLE)
-  SET(plugin_dest_dir eccoind.app/Contents/MacOS)
-  SET(qtconf_dest_dir eccoind.app/Contents/Resources)
-  SET(APPS "\${CMAKE_INSTALL_PREFIX}/eccoind.app")
+  SET(plugin_dest_dir Eccoind.app/Contents/MacOS)
+  SET(qtconf_dest_dir Eccoind.app/Contents/Resources)
+  SET(APPS "\${CMAKE_INSTALL_PREFIX}/Eccoind.app")
 ENDIF(APPLE)
 IF(WIN32)
-  SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/eccoind.exe")
+  SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/Eccoind.exe")
 ENDIF(WIN32)
 
 #--------------------------------------------------------------------------------
-# Install the QtTest application, on Apple, the bundle is at the root of the
+# Install the Eccoind application, on Apple, the bundle is at the root of the
 # install tree, and on other platforms it'll go into the bin directory.
-INSTALL(TARGETS eccoind
+INSTALL(TARGETS Eccoind
   BUNDLE DESTINATION . COMPONENT Runtime
   RUNTIME DESTINATION bin COMPONENT Runtime
 )
@@ -352,7 +350,7 @@ SET(DIRS ${ECC_LIBS})
 # over.
 INSTALL(CODE "
     include(BundleUtilities)
-    fixup_bundle(\"${APPS}\" \"${DIRS}\")
+    fixup_bundle(\"${APPS}\" \"\" \"${DIRS}\")
     " COMPONENT Runtime
 )
 

--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ECC Build System
-# 
+#
 # This CMakeLists.txt is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
 # with or without modifications, as long as this notice is preserved.
@@ -215,102 +215,149 @@ set(DIR_HEADERS
 
 #
 # Boost Dependencies
-# 
-set(Boost_USE_STATIC_LIBS OFF) 
-set(Boost_USE_MULTITHREADED ON)  
+#
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package( Boost REQUIRED COMPONENTS system filesystem thread date_time chrono regex serialization program_options )
 include_directories( ${Boost_INCLUDE_DIR} )
-# ucm_add_linker_flags(SHARED ${Boost_LIBRARY_DIRS})
 
-# 
+#
 # OpenSSL Dependencies
-# 
+#
+set(OPENSSL_USE_STATIC_LIBS ON)
 find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
-# ucm_add_linker_flags(SHARED ${OPENSSL_LIBRARIES})
 
 #
 # LibEvent Dependencies
-# 
+#
 find_package(LibEvent REQUIRED)
 include_directories(${LIBEVENT_INCLUDE_DIR})
 # ucm_add_linker_flags(SHARED ${LIBEVENT_LIB})
 
 #
 # BerkeleyDB
-# 
+#
 set(DB_VERSION 47)
 find_package(BerkeleyDB REQUIRED)
 include_directories(${BERKELEY_DB_INCLUDE_DIR})
 # ucm_add_linker_flags(SHARED ${BERKELEY_DB_LIBRARIES})
 
-# 
+#
 # LevelDB
-# 
+#
 add_subdirectory(leveldb)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/leveldb/include
                     ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/helpers
                     ${CMAKE_CURRENT_SOURCE_DIR}/leveldb/helpers/memenv)
 
-
+#
+# GMP
+#
+find_package(GMP REQUIRED)
+include_directories(${GMP_INCLUDE_DIR})
 
 #
 # univalue
-# 
+#
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/univalue)
 
-# 
+#
 # ECCoin
-# 
+#
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(eccoin ${DIR_HEADERS} ${DIR_SOURCES})
-
 
 #
 # secp256k1 - uses the original autotools
 #
 include(ExternalProject)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/include)
-ExternalProject_Add(SECP_EXTERNAL
+ExternalProject_Add(secp256k1
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/deps/secp256k1
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1
-  CONFIGURE_COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/configure
+  BUILD_IN_SOURCE 0
+  CONFIGURE_COMMAND
+    ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/configure
+    --prefix=<INSTALL_DIR>
   BUILD_COMMAND ${MAKE}
-  INSTALL_COMMAND "")
-
-ExternalProject_Get_Property(SECP_EXTERNAL INSTALL_DIR)
-set(SECKP_DIR ${INSTALL_DIR})
-add_dependencies(eccoin SECP_EXTERNAL)
-
-target_link_libraries(eccoin
-                      ${SECKP_DIR}/src/SECP_EXTERNAL-build
-                      ${Boost_LIBRARIES}
-                      ${OPENSSL_LIBRARIES}
-                      ${LIBEVENT_LIB}
-                      ${BERKELEY_DB_LIBRARIES}
-                      event_pthreads
-                      secp256k1
-                      leveldb
-                      
+  INSTALL_COMMAND ""
+)
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1
+  ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/src
+  ${CMAKE_CURRENT_SOURCE_DIR}/secp256k1/include
 )
 
-# add_library(SECP_LIB STATIC IMPORTED GLOBAL)
-# set_property(TARGET SECP_LIB PROPERTY IMPORTED_LOCATION ${SECKP_DIR}/src/secp256k1-build/libsecp256k1.la)
-# add_dependencies(SECP_LIB secp256k1)
+#
+# setup all the libraries
+#
+set(ECC_LIBS
+  ${Boost_LIBRARIES}
+  ${OPENSSL_LIBRARIES}
+  ${LIBEVENT_LIB}
+  ${LIBEVENT_PTHREADS_LIB}
+  ${BERKELEY_DB_LIBRARIES}
+  ${CMAKE_CURRENT_BINARY_DIR}/deps/secp256k1/src/secp256k1-build/.libs/libsecp256k1.a
+  ${GMP_LIBRARIES}
+  leveldb
+)
 
+#--------------------------------------------------------------------------------
+#  CMake's way of creating an executable
+add_executable(eccoind MACOSX_BUNDLE WIN32
+  ${DIR_HEADERS}
+  ${DIR_SOURCES}
+)
+add_dependencies(eccoind secp256k1)
 
-add_executable(eccoind ${DIR_HEADERS} ${DIR_SOURCES})
-target_link_libraries(eccoind eccoin)
+# Link the libraries into the binary
+target_link_libraries(eccoind ${ECC_LIBS})
 
-# include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-# add_executable(eccoind ${DIR_HEADERS} ${DIR_SOURCES})
-# target_link_libraries(eccoin
-#                       leveldb
-#                       -L${SECKP_DIR}/src/secp256k1-build
-#                       ${Boost_LIBRARY_DIRS}
-#                       ${OPENSSL_LIBRARIES}
-#                       ${LIBEVENT_LIB}
-#                       ${BERKELEY_DB_LIBRARIES}
-# )
+#--------------------------------------------------------------------------------
+# Now the installation stuff below
+#--------------------------------------------------------------------------------
+SET(plugin_dest_dir bin)
+SET(qtconf_dest_dir bin)
+SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/eccoind")
+IF(APPLE)
+  SET(plugin_dest_dir eccoind.app/Contents/MacOS)
+  SET(qtconf_dest_dir eccoind.app/Contents/Resources)
+  SET(APPS "\${CMAKE_INSTALL_PREFIX}/eccoind.app")
+ENDIF(APPLE)
+IF(WIN32)
+  SET(APPS "\${CMAKE_INSTALL_PREFIX}/bin/eccoind.exe")
+ENDIF(WIN32)
 
-# ucm_print_flags()
+#--------------------------------------------------------------------------------
+# Install the QtTest application, on Apple, the bundle is at the root of the
+# install tree, and on other platforms it'll go into the bin directory.
+INSTALL(TARGETS eccoind
+  BUNDLE DESTINATION . COMPONENT Runtime
+  RUNTIME DESTINATION bin COMPONENT Runtime
+)
+
+#--------------------------------------------------------------------------------
+# Use BundleUtilities to get all other dependencies for the application to work.
+# It takes a bundle or executable along with possible plugins and inspects it
+# for dependencies.  If they are not system dependencies, they are copied.
+
+# directories to look for dependencies
+SET(DIRS ${ECC_LIBS})
+
+# Now the work of copying dependencies into the bundle/package
+# The quotes are escaped and variables to use at install time have their $ escaped
+# An alternative is the do a configure_file() on a script and use install(SCRIPT  ...).
+# Note that the image plugins depend on QtSvg and QtXml, and it got those copied
+# over.
+INSTALL(CODE "
+    include(BundleUtilities)
+    fixup_bundle(\"${APPS}\" \"${DIRS}\")
+    " COMPONENT Runtime
+)
+
+# To Create a package, one can run "cpack -G DragNDrop CPackConfig.cmake" on Mac OS X
+# where CPackConfig.cmake is created by including CPack
+# And then there's ways to customize this as well
+set(CPACK_BINARY_DRAGNDROP ON)
+include(CPack)


### PR DESCRIPTION
This PR solves the issue with _dylib bundling_ with OSX, providing a full packaged binary output to the following plataforms:

- OSX _(tested, Sierra and High Sierra)_
- Windows 32 bits _(not tested)_
- Windows 64 Bits _(not tested)_
- Linux _(not tested)_

To do all the steps, follows:

```bash
# create a temporary builder folder and open it
$ mkdir build && cd build

# generate the configure scripts for your platform
$ cmake ../contrib/cmake/ # when your os have updated OpenSSL, NOT OSX
$ cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ../contrib/cmake/ # when you are OSX

# build the project
$ make -j8

# create the full bundled package
$ sudo cpack # you may need sudo to extract system dependencies
```

**Attention**

All the build process will generate in the `build` folder the following files:

- build/Eccoind.app **This is NOT the distribution application for OSX**
- build/ECC-0.1.1-Darwin.dmg **This is the distribution application for OSX**