### PR TITLE
Bug fix: ECC was using the wrong path for OSX

### DIFF
--- a/contrib/cmake/src/CMakeLists.txt
+++ b/contrib/cmake/src/CMakeLists.txt
@@ -301,6 +301,17 @@ set(ECC_LIBS
   leveldb
 )
 
+#
+# send definition headers
+#
+if(APPLE)
+  add_definitions(-DMAC_OSX)
+elseif(WIN32)
+  add_definitions(-DWIN32)
+else()
+  add_definitions(-DUNIX)
+endif()
+
 #--------------------------------------------------------------------------------
 #  CMake's way of creating an executable
 add_executable(Eccoind MACOSX_BUNDLE WIN32


### PR DESCRIPTION
This patch fixes the wrong path issue with OSX, where before this patch, it's using the Unix default path, which is: `~/.eccoin`.

The new path, specified by `util.cpp`, in `boost::filesystem::path GetDefaultDataDir()`, it's: `~/Library/Application Support/eccoin`.

## Attention

**Previous users using the OSX version should keep attention of your `wallet.dat` and already synced blocks. You may need to create the `~/Library/Application Support/eccoin` before running the daemon, and moving your files from `~/.eccoin` to there.**