### PR TITLE
fix gettxoutsetinfo rpc call

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -141,6 +141,55 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
     return ret;
 }
 
+CCoinsViewCursor *CCoinsViewDB::Cursor() const
+{
+    CCoinsViewDBCursor *i = new CCoinsViewDBCursor(const_cast<CDBWrapper &>(db).NewIterator(), GetBestBlock());
+    /* It seems that there are no "const iterators" for LevelDB.  Since we
+       only need read operations on it, use a const-cast to get around
+       that restriction.  */
+    i->pcursor->Seek(DB_COIN);
+    // Cache key of first record
+    if (i->pcursor->Valid())
+    {
+        CoinEntry entry(&i->keyTmp.second);
+        i->pcursor->GetKey(entry);
+        i->keyTmp.first = entry.key;
+    }
+    else
+    {
+        i->keyTmp.first = 0; // Make sure Valid() and GetKey() return false
+    }
+    return i;
+}
+
+bool CCoinsViewDBCursor::GetKey(COutPoint &key) const
+{
+    // Return cached key
+    if (keyTmp.first == DB_COIN)
+    {
+        key = keyTmp.second;
+        return true;
+    }
+    return false;
+}
+
+bool CCoinsViewDBCursor::GetValue(Coin &coin) const { return pcursor->GetValue(coin); }
+unsigned int CCoinsViewDBCursor::GetValueSize() const { return pcursor->GetValueSize(); }
+bool CCoinsViewDBCursor::Valid() const { return keyTmp.first == DB_COIN; }
+void CCoinsViewDBCursor::Next()
+{
+    pcursor->Next();
+    CoinEntry entry(&keyTmp.second);
+    if (!pcursor->Valid() || !pcursor->GetKey(entry))
+    {
+        keyTmp.first = 0; // Invalidate cached key after last record so that Valid() and GetKey() return false
+    }
+    else
+    {
+        keyTmp.first = entry.key;
+    }
+}
+
 CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe)
     : CDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe)
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -73,9 +73,33 @@ public:
         const uint256 &hashBlock,
         const uint64_t nBestCoinHeight,
         size_t &nChildCachedCoinsUsage) override;
+    CCoinsViewCursor *Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.
     bool Upgrade();
+};
+
+/** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */
+class CCoinsViewDBCursor : public CCoinsViewCursor
+{
+public:
+    ~CCoinsViewDBCursor() {}
+    bool GetKey(COutPoint &key) const override;
+    bool GetValue(Coin &coin) const override;
+    unsigned int GetValueSize() const override;
+
+    bool Valid() const override;
+    void Next() override;
+
+private:
+    CCoinsViewDBCursor(CDBIterator *pcursorIn, const uint256 &hashBlockIn)
+        : CCoinsViewCursor(hashBlockIn), pcursor(pcursorIn)
+    {
+    }
+    std::unique_ptr<CDBIterator> pcursor;
+    std::pair<char, COutPoint> keyTmp;
+
+    friend class CCoinsViewDB;
 };
 
 /** Access to the block database (blocks/index/) */


### PR DESCRIPTION
Fix reported crash when executing gettxoutsetinfo rpc call by adding `CCoinsViewDBCursor` class and overwriting `CCoinsView::Cursor()` implementation.