### PR TITLE
add initialblockdownload and size_on_disk to getblockchaininfo rpc

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -452,6 +452,9 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW = t
 /** Context-dependent validity checks */
 bool ContextualCheckBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindexPrev);
 
+/* Calculate the amount of disk space the block & undo files currently use */
+uint64_t CalculateCurrentUsage();
+
 extern std::set<CBlockIndex *, CBlockIndexWorkComparator> setBlockIndexCandidates;
 
 class CBlockFileInfo

--- a/src/rpc/rpcblockchain.cpp
+++ b/src/rpc/rpcblockchain.cpp
@@ -745,7 +745,10 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
             "  \"difficulty\": xxxxxx,     (numeric) the current difficulty\n"
             "  \"mediantime\": xxxxxx,     (numeric) median time for the current best block\n"
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
+            "  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial "
+            "Block Download mode.\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+            "  \"size_on_disk\": xxxxxx,       (numeric) the estimated size of the block and undo files on disk\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
             "  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
@@ -787,7 +790,9 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     obj.push_back(Pair("verificationprogress",
         Checkpoints::GuessVerificationProgress(pnetMan->getActivePaymentNetwork()->Checkpoints(),
                            pnetMan->getChainActive()->chainActive.Tip())));
+    obj.push_back(Pair("initialblockdownload", pnetMan->getChainActive()->IsInitialBlockDownload()));
     obj.push_back(Pair("chainwork", pnetMan->getChainActive()->chainActive.Tip()->nChainWork.GetHex()));
+    obj.push_back(Pair("size_on_disk", CalculateCurrentUsage()));
 
     const Consensus::Params &consensusParams = pnetMan->getActivePaymentNetwork()->GetConsensus();
     CBlockIndex *tip = pnetMan->getChainActive()->chainActive.Tip();


### PR DESCRIPTION
```
$ eccoind getblockchaininfo
{
  "chain": "LEGACY",
  "blocks": 2139511,
  "headers": 2139511,
  "bestblockhash": "1de5f4eb3bcbb6d5a8659e7e1dc9d3fb70e2357100c02bf1d4eb1388cb350fed",
  "difficulty": 4314.59789941081,
  "mediantime": 1557215017,
  "verificationprogress": 0,
  "initialblockdownload": false,
  "chainwork": "000000000000000000000000000000000000000000000000c435db71affc3007",
  "size_on_disk": 1485950168,
  "softforks": [
    {
      "id": "bip34",
      "version": 2,
      "enforce": {
        "status": true,
        "found": 1000,
        "required": 750,
        "window": 1000
      },
      "reject": {
        "status": true,
        "found": 1000,
        "required": 950,
        "window": 1000
      }
    },
    {
      "id": "bip66",
      "version": 3,
      "enforce": {
        "status": true,
        "found": 1000,
        "required": 750,
        "window": 1000
      },
      "reject": {
        "status": true,
        "found": 1000,
        "required": 950,
        "window": 1000
      }
    },
    {
      "id": "bip65",
      "version": 4,
      "enforce": {
        "status": true,
        "found": 1000,
        "required": 750,
        "window": 1000
      },
      "reject": {
        "status": true,
        "found": 1000,
        "required": 950,
        "window": 1000
      }
    }
  ],
  "bip9_softforks": [
  ]
}
```