### PR TITLE
Added RPC getzmqnotifications

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -161,7 +161,7 @@ BITCOIN_CORE_H = \
   wallet/wallet_ismine.h \
   wallet/walletdb.h \
   zmq/zmqabstractnotifier.h \
-  zmq/zmqconfig.h\
+  zmq/zmqconfig.h \
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h
 
@@ -298,7 +298,8 @@ libbitcoin_zmq_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_zmq_a_SOURCES = \
   zmq/zmqabstractnotifier.cpp \
   zmq/zmqnotificationinterface.cpp \
-  zmq/zmqpublishnotifier.cpp
+  zmq/zmqpublishnotifier.cpp \
+  zmq/zmqrpc.cpp
 endif
 
 if GLIBC_BACK_COMPAT

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -62,8 +62,7 @@
 #include <openssl/crypto.h>
 
 #if ENABLE_ZMQ
-#include "zmq/zmqnotificationinterface.h"
-static CZMQNotificationInterface *pzmqNotificationInterface = nullptr;
+#include <zmq/zmqnotificationinterface.h>
 #endif
 
 extern std::unique_ptr<PeerLogicValidation> peerLogic;
@@ -257,11 +256,11 @@ void Shutdown(thread_group &threadGroup)
     }
 
 #if ENABLE_ZMQ
-    if (pzmqNotificationInterface)
+    if (g_zmq_notification_interface)
     {
-        UnregisterValidationInterface(pzmqNotificationInterface);
-        delete pzmqNotificationInterface;
-        pzmqNotificationInterface = NULL;
+        UnregisterValidationInterface(g_zmq_notification_interface);
+        delete g_zmq_notification_interface;
+        g_zmq_notification_interface = NULL;
     }
 #endif
 
@@ -1592,10 +1591,10 @@ bool AppInit2(thread_group &threadGroup)
     }
 
 #if ENABLE_ZMQ
-    pzmqNotificationInterface = CZMQNotificationInterface::CreateWithArguments(gArgs.GetMapArgs());
-    if (pzmqNotificationInterface)
+    g_zmq_notification_interface = CZMQNotificationInterface::CreateWithArguments(gArgs.GetMapArgs());
+    if (g_zmq_notification_interface)
     {
-        RegisterValidationInterface(pzmqNotificationInterface);
+        RegisterValidationInterface(g_zmq_notification_interface);
     }
 #endif
 

--- a/src/rpc/rpcserver.cpp
+++ b/src/rpc/rpcserver.cpp
@@ -361,6 +361,11 @@ static const CRPCCommand vRPCCommands[] = {
     {"wallet", "settxfee", &settxfee, true}, {"wallet", "signmessage", &signmessage, true},
     {"wallet", "walletlock", &walletlock, true}, {"wallet", "walletpassphrasechange", &walletpassphrasechange, true},
     {"wallet", "walletpassphrase", &walletpassphrase, true},
+
+#if ENABLE_ZMQ
+    /* ZMQ */
+    {"zmq", "getzmqnotifications", &getzmqnotifications, true},
+#endif
 };
 
 CRPCTable::CRPCTable()

--- a/src/rpc/rpcserver.h
+++ b/src/rpc/rpcserver.h
@@ -21,6 +21,10 @@
 
 #include <univalue.h>
 
+#ifdef HAVE_CONFIG_H
+#include "config/bitcoin-config.h"
+#endif
+
 class CRPCCommand;
 
 namespace RPCServer
@@ -270,6 +274,9 @@ extern UniValue getroutingpubkey(const UniValue &params, bool fHelp);
 extern UniValue findroute(const UniValue &params, bool fHelp);
 extern UniValue haveroute(const UniValue &params, bool fHelp);
 
+#if ENABLE_ZMQ
+extern UniValue getzmqnotifications(const UniValue &params, bool fHelp);
+#endif
 
 bool StartRPC();
 void InterruptRPC();

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -23,6 +23,16 @@ CZMQNotificationInterface::~CZMQNotificationInterface()
     }
 }
 
+std::list<const CZMQAbstractNotifier*> CZMQNotificationInterface::GetActiveNotifiers() const
+{
+    std::list<const CZMQAbstractNotifier*> result;
+    for (const auto* n : notifiers)
+    {
+        result.push_back(n);
+    }
+    return result;
+}
+
 CZMQNotificationInterface *CZMQNotificationInterface::CreateWithArguments(
     const std::map<std::string, std::string> &args)
 {
@@ -153,3 +163,5 @@ void CZMQNotificationInterface::SyncTransaction(const CTransactionRef &ptx, cons
         }
     }
 }
+
+CZMQNotificationInterface* g_zmq_notification_interface = NULL;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -18,6 +18,8 @@ class CZMQNotificationInterface : public CValidationInterface
 public:
     virtual ~CZMQNotificationInterface();
 
+    std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
+
     static CZMQNotificationInterface *CreateWithArguments(const std::map<std::string, std::string> &args);
 
 protected:
@@ -34,5 +36,7 @@ private:
     void *pcontext;
     std::list<CZMQAbstractNotifier *> notifiers;
 };
+
+extern CZMQNotificationInterface *g_zmq_notification_interface;
 
 #endif // BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H

--- a/src/zmq/zmqrpc.cpp
+++ b/src/zmq/zmqrpc.cpp
@@ -1,0 +1,44 @@
+// This file is part of the Eccoin project
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2019 The Eccoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpc/rpcserver.h"
+#include "util/logger.h"
+#include "util/utilstrencodings.h"
+#include <univalue.h>
+
+#include <zmq/zmqabstractnotifier.h>
+#include <zmq/zmqnotificationinterface.h>
+
+#include <univalue.h>
+
+UniValue getzmqnotifications(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw std::runtime_error("getzmqnotifications\n"
+                                 "\nReturns information about the active ZeroMQ notifications.\n"
+                                 "\nResult:\n"
+                                 "[\n"
+                                 "  {                        (json object)\n"
+                                 "    \"type\": \"pubhashtx\",   (string) Type of notification\n"
+                                 "    \"address\": \"...\",      (string) Address of the publisher\n"
+                                 "  },\n"
+                                 "  ...\n"
+                                 "]\n"
+                                 "\nExamples:\n" +
+                                 HelpExampleCli("getzmqnotifications", "") + HelpExampleRpc("getzmqnotifications", ""));
+
+    UniValue ret(UniValue::VARR);
+    if (g_zmq_notification_interface != NULL) {
+        for (const auto* n : g_zmq_notification_interface->GetActiveNotifiers()) {
+            UniValue obj(UniValue::VOBJ);
+            obj.push_back(Pair("type", n->GetType()));
+            obj.push_back(Pair("address", n->GetAddress()));
+            ret.push_back(obj);
+        }
+    }
+
+    return ret;
+}


### PR DESCRIPTION
This adds Bitcoin's RPC getzmqnotifications.

Given the following in eccoin.conf:

zmqpubhashblock=tcp://127.0.0.1:28333
zmqpubhashtx=tcp://127.0.0.1:28333
zmqpubrawblock=tcp://127.0.0.1:28333
zmqpubrawtx=tcp://127.0.0.1:28333

Calling the RPC method getzmqnotifications will return:

[
  {
    "type": "pubhashblock",
    "address": "tcp://127.0.0.1:28333"
  },
  {
    "type": "pubhashtx",
    "address": "tcp://127.0.0.1:28333"
  },
  {
    "type": "pubrawblock",
    "address": "tcp://127.0.0.1:28333"
  },
  {
    "type": "pubrawtx",
    "address": "tcp://127.0.0.1:28333"
  }
]
