### PR TITLE
Implemented system message notifications with ZMQ bindings

### DIFF
--- a/qa/rpc-tests/zmq_test_system.py
+++ b/qa/rpc-tests/zmq_test_system.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+#
+# Test ZMQ interface system messages
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import zmq
+import struct
+
+import http.client
+import urllib.parse
+
+class ZMQTest (BitcoinTestFramework):
+
+    port = 28332
+
+    def setup_nodes(self):
+        self.zmqContext = zmq.Context()
+        self.zmqSubSocket = self.zmqContext.socket(zmq.SUB)
+        self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"system")
+        self.zmqSubSocket.linger = 500
+        self.zmqSubSocket.connect("tcp://127.0.0.1:%i" % self.port)
+        return start_nodes(1, self.options.tmpdir, extra_args=[
+            ['-zmqpubsystem=tcp://127.0.0.1:'+str(self.port)],
+            [],
+            [],
+            []
+            ])
+
+    def run_test(self):
+        try:
+            self.sync_all()
+
+            print("listen...")
+            msg = self.zmqSubSocket.recv_multipart()
+            topic = msg[0]
+            body = msg[1]
+
+            assert_equal(msg[1], "STARTUP: RPC AVAILABLE")
+
+        finally:
+            self.zmqSubSocket.close()
+            self.zmqSubSocket = None
+            self.zmqContext.destroy()
+            self.zmqContext = None
+
+
+if __name__ == '__main__':
+    ZMQTest ().main ()
+
+def Test():
+    ZMQTest ().main ()
+ 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -173,6 +173,7 @@ void Interrupt(thread_group &threadGroup)
 
 void Shutdown(thread_group &threadGroup)
 {
+    GetMainSignals().SystemMessage("SHUTDOWN: INITIATED");
     LogPrintf("%s: In progress...\n", __func__);
     static CCriticalSection cs_Shutdown;
     TRY_LOCK(cs_Shutdown, lockShutdown);
@@ -1644,6 +1645,7 @@ bool AppInit2(thread_group &threadGroup)
 
     SetRPCWarmupFinished();
     LogPrintf("Done loading\n");
+    GetMainSignals().SystemMessage("STARTUP: RPC AVAILABLE");
 
 
     if (pwalletMain)

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -1287,12 +1287,6 @@ UniValue estimatefee(const UniValue &params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
-    /* This is a temporary fix pending fee estimation working correctly and/or properly handling empty blocks */
-
-    return 1;
-
-    /* End of temporary fix */
-
     CFeeRate feeRate = mempool.estimateFee(nBlocks);
     if (feeRate == CFeeRate(0))
         return -1.0;

--- a/src/rpc/rpcmining.cpp
+++ b/src/rpc/rpcmining.cpp
@@ -1287,6 +1287,12 @@ UniValue estimatefee(const UniValue &params, bool fHelp)
     if (nBlocks < 1)
         nBlocks = 1;
 
+    /* This is a temporary fix pending fee estimation working correctly and/or properly handling empty blocks */
+
+    return 1;
+
+    /* End of temporary fix */
+
     CFeeRate feeRate = mempool.estimateFee(nBlocks);
     if (feeRate == CFeeRate(0))
         return -1.0;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -20,6 +20,7 @@ void RegisterValidationInterface(CValidationInterface *pwalletIn)
     g_signals.BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.ScriptForMining.connect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
     g_signals.NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.SystemMessage.connect(boost::bind(&CValidationInterface::SystemMessage, pwalletIn, _1));
 }
 
 void UnregisterValidationInterface(CValidationInterface *pwalletIn)
@@ -32,6 +33,7 @@ void UnregisterValidationInterface(CValidationInterface *pwalletIn)
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
     g_signals.NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.SystemMessage.disconnect(boost::bind(&CValidationInterface::SystemMessage, pwalletIn, _1));
 }
 
 void UnregisterAllValidationInterfaces()
@@ -44,6 +46,7 @@ void UnregisterAllValidationInterfaces()
     g_signals.SyncTransaction.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
     g_signals.NewPoWValidBlock.disconnect_all_slots();
+    g_signals.SystemMessage.disconnect_all_slots();
 }
 
 void SyncWithWallets(const CTransactionRef &ptx, const CBlock *pblock, int txIdx)

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -46,6 +46,7 @@ protected:
     virtual void BlockChecked(const CBlock &, const CValidationState &) {}
     virtual void GetScriptForMining(boost::shared_ptr<CReserveScript> &){};
     virtual void NewPoWValidBlock(CBlockIndex *pindex, const CBlock *block) {}
+    virtual void SystemMessage(const std::string &message) {}
     friend void ::RegisterValidationInterface(CValidationInterface *);
     friend void ::UnregisterValidationInterface(CValidationInterface *);
     friend void ::UnregisterAllValidationInterfaces();
@@ -73,6 +74,8 @@ struct CMainSignals
      * yet.
      */
     boost::signals2::signal<void(CBlockIndex *, const CBlock *)> NewPoWValidBlock;
+    /** Notifies listeners that a system message notification has been raised */
+    boost::signals2::signal<void(const std::string &)> SystemMessage;
 };
 
 CMainSignals &GetMainSignals();

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -10,3 +10,4 @@
 CZMQAbstractNotifier::~CZMQAbstractNotifier() { assert(!psocket); }
 bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/) { return true; }
 bool CZMQAbstractNotifier::NotifyTransaction(const CTransactionRef & /*transaction*/) { return true; }
+bool CZMQAbstractNotifier::NotifySystem(const std::string & /*message*/) { return true; }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -34,6 +34,7 @@ public:
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransactionRef &ptx);
+    virtual bool NotifySystem(const std::string &message);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -29,6 +29,7 @@ protected:
     // CValidationInterface
     void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex = -1);
     void UpdatedBlockTip(const CBlockIndex *pindex);
+    void SystemMessage(const std::string &message);
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -174,3 +174,12 @@ bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransactionRef 
     int rc = zmq_send_multipart(psocket, "rawtx", 5, &(*ss.begin()), ss.size(), 0);
     return rc == 0;
 }
+
+bool CZMQPublishSystemNotifier::NotifySystem(const std::string &message)
+{
+    LogPrint("zmq", "zmq: Publish system %s\n", message);
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << message;
+    int rc = zmq_send_multipart(psocket, "system", 6, &(*ss.begin()), ss.size(), 0);
+    return rc == 0;
+}

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -41,4 +41,10 @@ public:
     bool NotifyTransaction(const CTransactionRef &ptx);
 };
 
+class CZMQPublishSystemNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifySystem(const std::string &message);
+};
+
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
Implemented new "pubsystem" notification with ZMQ bindings. New config entry added, example:

zmqpubsystem=tcp://127.0.0.1:28000

The eccoind daemon will publish the following notification messages to this topic:

STARTUP: RPC AVAILABLE
SHUTDOWN: INITIATED

New test in zmq_test_system.py