### PR TITLE
Implemented packet notification with ZMQ binding

### DIFF
--- a/src/net/packetmanager.h
+++ b/src/net/packetmanager.h
@@ -15,6 +15,7 @@
 #include "net.h"
 #include "pubkey.h"
 #include "util/utiltime.h"
+#include "validationinterface.h"
 
 static const int64_t DEFAULT_PACKET_TIMEOUT = 30; // 30 seconds
 
@@ -64,6 +65,7 @@ private:
         }
         mapPacketLastUpdated.erase(nonce);
         mapPartialPackets.erase(nonce);
+        GetMainSignals().PacketComplete(protocolId);
     }
 
 public:

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -21,6 +21,7 @@ void RegisterValidationInterface(CValidationInterface *pwalletIn)
     g_signals.ScriptForMining.connect(boost::bind(&CValidationInterface::GetScriptForMining, pwalletIn, _1));
     g_signals.NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
     g_signals.SystemMessage.connect(boost::bind(&CValidationInterface::SystemMessage, pwalletIn, _1));
+    g_signals.PacketComplete.connect(boost::bind(&CValidationInterface::PacketComplete, pwalletIn, _1));
 }
 
 void UnregisterValidationInterface(CValidationInterface *pwalletIn)
@@ -34,6 +35,7 @@ void UnregisterValidationInterface(CValidationInterface *pwalletIn)
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
     g_signals.NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
     g_signals.SystemMessage.disconnect(boost::bind(&CValidationInterface::SystemMessage, pwalletIn, _1));
+    g_signals.PacketComplete.disconnect(boost::bind(&CValidationInterface::PacketComplete, pwalletIn, _1));
 }
 
 void UnregisterAllValidationInterfaces()
@@ -47,6 +49,7 @@ void UnregisterAllValidationInterfaces()
     g_signals.UpdatedBlockTip.disconnect_all_slots();
     g_signals.NewPoWValidBlock.disconnect_all_slots();
     g_signals.SystemMessage.disconnect_all_slots();
+    g_signals.PacketComplete.disconnect_all_slots();
 }
 
 void SyncWithWallets(const CTransactionRef &ptx, const CBlock *pblock, int txIdx)

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -47,6 +47,7 @@ protected:
     virtual void GetScriptForMining(boost::shared_ptr<CReserveScript> &){};
     virtual void NewPoWValidBlock(CBlockIndex *pindex, const CBlock *block) {}
     virtual void SystemMessage(const std::string &message) {}
+    virtual void PacketComplete(const uint8_t nProtocolId) {}
     friend void ::RegisterValidationInterface(CValidationInterface *);
     friend void ::UnregisterValidationInterface(CValidationInterface *);
     friend void ::UnregisterAllValidationInterfaces();
@@ -76,6 +77,8 @@ struct CMainSignals
     boost::signals2::signal<void(CBlockIndex *, const CBlock *)> NewPoWValidBlock;
     /** Notifies listeners that a system message notification has been raised */
     boost::signals2::signal<void(const std::string &)> SystemMessage;
+    /** Notifies listeners that a received packet is complete */
+    boost::signals2::signal<void(const uint8_t)> PacketComplete;
 };
 
 CMainSignals &GetMainSignals();

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -11,3 +11,4 @@ CZMQAbstractNotifier::~CZMQAbstractNotifier() { assert(!psocket); }
 bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/) { return true; }
 bool CZMQAbstractNotifier::NotifyTransaction(const CTransactionRef & /*transaction*/) { return true; }
 bool CZMQAbstractNotifier::NotifySystem(const std::string & /*message*/) { return true; }
+bool CZMQAbstractNotifier::NotifyPacket(const uint8_t /*nProtocolId*/) { return true; }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -35,6 +35,7 @@ public:
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransactionRef &ptx);
     virtual bool NotifySystem(const std::string &message);
+    virtual bool NotifyPacket(const uint8_t nProtocolId);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -45,6 +45,7 @@ CZMQNotificationInterface *CZMQNotificationInterface::CreateWithArguments(
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
     factories["pubsystem"] = CZMQAbstractNotifier::Create<CZMQPublishSystemNotifier>;
+    factories["pubpacket"] = CZMQAbstractNotifier::Create<CZMQPublishPacketNotifier>;
 
     for (std::map<std::string, CZMQNotifierFactory>::const_iterator i = factories.begin(); i != factories.end(); ++i)
     {
@@ -174,6 +175,23 @@ void CZMQNotificationInterface::SystemMessage(const std::string &message)
     {
         CZMQAbstractNotifier *notifier = *i;
         if (notifier->NotifySystem(message))
+        {
+            i++;
+        }
+        else
+        {
+            notifier->Shutdown();
+            i = notifiers.erase(i);
+        }
+    }
+}
+
+void CZMQNotificationInterface::PacketComplete(const uint8_t nProtocolId)
+{
+    for (std::list<CZMQAbstractNotifier *>::iterator i = notifiers.begin(); i != notifiers.end();)
+    {
+        CZMQAbstractNotifier *notifier = *i;
+        if (notifier->NotifyPacket(nProtocolId))
         {
             i++;
         }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -30,6 +30,7 @@ protected:
     void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex = -1);
     void UpdatedBlockTip(const CBlockIndex *pindex);
     void SystemMessage(const std::string &message);
+    void PacketComplete(const uint8_t nProtocolId);
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -182,3 +182,13 @@ bool CZMQPublishSystemNotifier::NotifySystem(const std::string &message)
     int rc = zmq_send_multipart(psocket, "system", 6, &(*ss.begin()), ss.size(), 0);
     return rc == 0;
 }
+
+bool CZMQPublishPacketNotifier::NotifyPacket(const uint8_t nProtocolId)
+{
+    LogPrint("zmq", "zmq: Publish packet %d\n", nProtocolId);
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    std::string str = std::to_string(nProtocolId);
+    ss << str;
+    int rc = zmq_send_multipart(psocket, "packet", 6, &(*ss.begin()), ss.size(), 0);
+    return rc == 0;
+}

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -47,4 +47,10 @@ public:
     bool NotifySystem(const std::string &message);
 };
 
+class CZMQPublishPacketNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyPacket(const uint8_t nProtocolId);
+};
+
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
New configuration setting - example:

zmqpubpacket=tcp://127.0.0.1:28001

Notification reports Protocol ID of received packet.