### PR TITLE
Removed ShowProgress and implemented ZMQ rescan notifications

### DIFF
--- a/src/rpc/rpcdump.cpp
+++ b/src/rpc/rpcdump.cpp
@@ -318,11 +318,8 @@ UniValue importwallet(const UniValue &params, bool fHelp)
     int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
     file.seekg(0, file.beg);
 
-    pwalletMain->ShowProgress("Importing...", 0); // show progress dialog in GUI
     while (file.good())
     {
-        pwalletMain->ShowProgress(
-            "", std::max(1, std::min(99, (int)(((double)file.tellg() / (double)nFilesize) * 100))));
         std::string line;
         std::getline(file, line);
         if (line.empty() || line[0] == '#')
@@ -373,7 +370,6 @@ UniValue importwallet(const UniValue &params, bool fHelp)
         nTimeBegin = std::min(nTimeBegin, nTime);
     }
     file.close();
-    pwalletMain->ShowProgress("", 100); // hide progress dialog in GUI
 
     CBlockIndex *pindex = pnetMan->getChainActive()->chainActive.Tip();
     while (pindex && pindex->pprev && pindex->GetBlockTime() > nTimeBegin - 7200)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1243,9 +1243,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate)
         {
             pindex = pnetMan->getChainActive()->chainActive.Next(pindex);
         }
-
-        // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
-        ShowProgress(("Rescanning..."), 0);
+        GetMainSignals().SystemMessage("RESCAN: STARTED");
         while (pindex)
         {
             CBlock block;
@@ -1264,9 +1262,10 @@ int CWallet::ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate)
             {
                 nNow = GetTime();
                 LogPrintf("Still rescanning. At block %d out of %d\n", pindex->nHeight, nEndHeight);
+                GetMainSignals().SystemMessage(strprintf("RESCAN: BLOCK %d of %d", pindex->nHeight, nEndHeight));
             }
         }
-        ShowProgress(("Rescanning..."), 100); // hide progress dialog in GUI
+        GetMainSignals().SystemMessage("RESCAN: COMPLETE");
     }
     return ret;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -786,9 +786,6 @@ public:
     //! Verify the wallet database and perform salvage if required
     static bool Verify(const std::string &walletFile, std::string &warningString, std::string &errorString);
 
-    /** Show progress e.g. for rescan */
-    boost::signals2::signal<void(const std::string &title, int nProgress)> ShowProgress;
-
     /** Watch-only address added */
     boost::signals2::signal<void(bool fHaveWatchOnly)> NotifyWatchonlyChanged;
 


### PR DESCRIPTION
ShowProgress (a vestige of the previously removed Qt wallet) completely removed.
ZMQ notifications for rescan (and all actions with a rescan as a side effect - importaddress, importprivkey, importpubkey) added on the "pubsystem" topic per the example below:

RESCAN: STARTED
RESCAN: BLOCK 54910 of 2245272
RESCAN: BLOCK 144117 of 2245272
RESCAN: BLOCK 256863 of 2245272
RESCAN: BLOCK 368736 of 2245272
RESCAN: BLOCK 484255 of 2245272
RESCAN: BLOCK 599815 of 2245272
RESCAN: BLOCK 715423 of 2245272
RESCAN: BLOCK 830663 of 2245272
RESCAN: BLOCK 946172 of 2245272
RESCAN: BLOCK 1061969 of 2245272
RESCAN: BLOCK 1177833 of 2245272
RESCAN: BLOCK 1293514 of 2245272
RESCAN: BLOCK 1409029 of 2245272
RESCAN: BLOCK 1523764 of 2245272
RESCAN: BLOCK 1639231 of 2245272
RESCAN: BLOCK 1754775 of 2245272
RESCAN: BLOCK 1870354 of 2245272
RESCAN: BLOCK 1985769 of 2245272
RESCAN: BLOCK 2101179 of 2245272
RESCAN: BLOCK 2216949 of 2245272
RESCAN: COMPLETE

Note this does not work for startup rescans using the command line -rescan option because ZMQ is not available in that phase of the startup process.