### PR TITLE
Implemented ZMQ reindex notifications

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -687,6 +687,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
     {
         CImportingNow imp;
         int nFile = 0;
+        GetMainSignals().SystemMessage("REINDEX: STARTED");
         while (true)
         {
             CDiskBlockPos pos(nFile, 0);
@@ -700,12 +701,14 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
                 break; // This error is logged in OpenBlockFile
             }
             LogPrintf("Reindexing block file blk%05u.dat...\n", (unsigned int)nFile);
+            GetMainSignals().SystemMessage(strprintf("REINDEX: BLOCK FILE blk%05u.dat", (unsigned int)nFile));
             pnetMan->getChainActive()->LoadExternalBlockFile(chainparams, file, &pos);
             nFile++;
         }
         pblocktree->WriteReindexing(false);
         fReindex = false;
         LogPrintf("Reindexing finished\n");
+        GetMainSignals().SystemMessage("REINDEX: COMPLETE");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
         pnetMan->getChainActive()->InitBlockIndex(chainparams);
     }


### PR DESCRIPTION
ZMQ notifications for reindex added on the "pubsystem" topic per the example below:

REINDEX: STARTED
REINDEX: BLOCK FILE blk00001.dat
REINDEX: BLOCK FILE blk00002.dat
REINDEX: BLOCK FILE blk00003.dat
REINDEX: BLOCK FILE blk00004.dat
REINDEX: BLOCK FILE blk00005.dat
REINDEX: BLOCK FILE blk00006.dat
REINDEX: BLOCK FILE blk00007.dat
REINDEX: BLOCK FILE blk00008.dat
REINDEX: BLOCK FILE blk00009.dat
REINDEX: COMPLETE

Note that starting eccoind with -reindex is a lengthy process taking >5 hours on modest hardware. The process is CPU bound seems not to be sped up by setting -dbcache as suggested in Bitcoin documentation.