### PR TITLE
Compiler warning fixes

### DIFF
--- a/src/leveldb/port/port_posix.cc
+++ b/src/leveldb/port/port_posix.cc
@@ -55,7 +55,7 @@ void InitOnce(OnceType* once, void (*initializer)()) {
 
 bool HasAcceleratedCRC32C() {
 #if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
-  unsigned int eax, ebx, ecx, edx;
+  unsigned int eax(0), ebx(0), ecx(0), edx(0);
   __get_cpuid(1, &eax, &ebx, &ecx, &edx);
   return (ecx & (1 << 20)) != 0;
 #else

--- a/src/rpc/rpcdump.cpp
+++ b/src/rpc/rpcdump.cpp
@@ -315,7 +315,6 @@ UniValue importwallet(const UniValue &params, bool fHelp)
 
     bool fGood = true;
 
-    int64_t nFilesize = std::max((int64_t)1, (int64_t)file.tellg());
     file.seekg(0, file.beg);
 
     while (file.good())


### PR DESCRIPTION
Two compiler warning fixes:
port_posix.cc - uninitialized variables
rpcdump.cpp - unused variable